### PR TITLE
Add a PORT_DTLS constant

### DIFF
--- a/lib/core/coap/coap.rb
+++ b/lib/core/coap/coap.rb
@@ -17,6 +17,7 @@ module CoRE
     METHODS_I = invert_into_hash(METHODS)
 
     PORT = 5683
+    PORT_DTLS = 5684
 
     # Shortcut: CoRE::CoAP::parse == CoRE::CoAP::Message.parse
     def self.parse(*args)


### PR DESCRIPTION
From RFC 7252:

	All of the requirements listed above for the "coap" scheme are
	also requirements for the "coaps" scheme, except that a default
	UDP port of 5684 is assumed if the port subcomponent is empty or
	not given [...].