### PR TITLE
CI matrix with 2.6.0, latest JRuby; JRuby --debug setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ notifications:
 env:
   global:
     - JRUBY_OPTS="--debug"
-  matrix:
     - NO_IPV6_TESTS=1
-
 
 script:
   - bundle exec rake build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ rvm:
 matrix:
   fast_finish: true
   allow_failures:
-    - os: osx
     - rvm: jruby-9.2.5.0
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,26 @@ os:
   - osx
 
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - jruby-9.1.17.0
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
+  - jruby-9.2.5.0
 
 matrix:
   fast_finish: true
   allow_failures:
     - os: osx
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.5.0
 
 notifications:
   email: false
 
 env:
-  - NO_IPV6_TESTS=1
+  global:
+    - JRUBY_OPTS="--debug"
+  matrix:
+    - NO_IPV6_TESTS=1
+
 
 script:
   - bundle exec rake build


### PR DESCRIPTION
This PR updates the CI matrix

- add Ruby 2.6
- update to latest patch releases
- add a JRuby setting to actually count code coverage