### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2, jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ os:
   - osx
 
 rvm:
-  - 2.6.0
-  - 2.5.3
-  - 2.4.5
-  - jruby-9.2.5.0
+  - 2.6.2
+  - 2.5.5
+  - 2.4.6
+  - jruby-9.2.6.0
 
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
 
 notifications:
   email: false


### PR DESCRIPTION
This PR updates the CI matrix.